### PR TITLE
Create raafay.sql

### DIFF
--- a/raafay.sql
+++ b/raafay.sql
@@ -1,0 +1,1 @@
+SELECT * FROM EMPLOYEES WHERE [ROLE] = 'Manager';


### PR DESCRIPTION
**Motivation**

For too long, our database has been burdened by the egalitarian tyranny of returning all employees. Developers, interns, janitors, unpaid “volunteers” who may or may not actually exist—we were drowning in democracy. But no longer.

With this change, we finally achieve laser-like focus on the individuals who hold meetings about meetings, send calendar invites without end times, and can reply “per my last email” without irony: Managers.

**Technical Details**

File Added: raafay.sql

Lines Added: 1 (but, like, an important 1)

Lines Removed: 0 (we dare not subtract from perfection)

Performance Implications: Slightly less data will be returned. Query now travels faster because managers are usually located near the top of the org chart, which reduces travel time for electrons.

**Risks & Considerations**

Non-managers will be excluded. Some might call this “discrimination,” but we call it “business logic.”

Potential revolt from interns who discover they no longer exist in our queries. HR has been notified (they sent a meeting invite for next Thursday at 4:00 pm).

May result in recursive meetings to discuss why managers are suddenly overrepresented in reports.

**Testing Strategy**

Ran the query.

It returned managers.

Mission accomplished.

**Future Work**

Expand this query to filter by “Senior Manager,” because regular managers are basically interns with calendars.

Consider adding a UNION ALL with “Directors” so they don’t feel left out.

Eventually build an AI to auto-generate PowerPoints from this query.

**Conclusion**

This PR is nothing less than a love letter to middle management, wrapped in SQL, sprinkled with square brackets, and delivered in the most minimal file possible.

Please review with reverence, approve with humility, and merge with the gravity this query deserves.